### PR TITLE
Add scene_tree_folders addon

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "addons/scene_tree_folders"]
+	path = addons/scene_tree_folders
+	url = https://github.com/TheGrandJaggard/godot_scene_tree_folders.git


### PR DESCRIPTION
Adds the scene_tree_folders addon for hierarchy organization.
View the addon on [the asset store](https://godotengine.org/asset-library/asset/4084) or on [GitHub](https://github.com/nathan-coleman/godot_scene_tree_folders).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added a new submodule for scene tree folders to enhance project modularity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->